### PR TITLE
:recycle: Move video_id from Detection to Track.

### DIFF
--- a/tests/unit/test_detection_service.py
+++ b/tests/unit/test_detection_service.py
@@ -72,7 +72,6 @@ class ShouldMapBatchOutputToDetectionsCases:
         frames = [Frame(id=FRAME_ID_0, position=0, video_id=VIDEO_ID, data=np.array([[1, 0]], dtype=np.uint8))]
         expected = [
             Detection(
-                video_id=VIDEO_ID,
                 frame_id=FRAME_ID_0,
                 bbox=BoundingBox(center_x=0, center_y=0, width=1, height=1, confidence=0.5, label=ClassLabel.PEOPLE),
             )
@@ -86,12 +85,10 @@ class ShouldMapBatchOutputToDetectionsCases:
         ]
         expected = [
             Detection(
-                video_id=VIDEO_ID,
                 frame_id=FRAME_ID_0,
                 bbox=BoundingBox(center_x=0, center_y=0, width=1, height=1, confidence=0.5, label=ClassLabel.PEOPLE),
             ),
             Detection(
-                video_id=VIDEO_ID,
                 frame_id=FRAME_ID_1,
                 bbox=BoundingBox(center_x=1, center_y=0, width=1, height=1, confidence=0.5, label=ClassLabel.VEHICLE),
             ),

--- a/tests/unit/test_pipeline_controller.py
+++ b/tests/unit/test_pipeline_controller.py
@@ -66,7 +66,8 @@ class ThisContext:
     controller: PipelineController
 
 
-def _make_context(batch_size: int) -> ThisContext:
+@pytest.fixture(scope="function")
+def this_context() -> ThisContext:
     video_reader = StubVideoReader()
     frame_repository = InMemoryFrameRepository()
     detection_store = InMemoryDetectionStore()
@@ -83,7 +84,7 @@ def _make_context(batch_size: int) -> ThisContext:
         detection_service=detection_service,
         detection_store=detection_store,
         track_use_case=track_use_case,
-        batch_size=batch_size,
+        batch_size=2,
     )
     return ThisContext(
         video_reader=video_reader,
@@ -92,11 +93,6 @@ def _make_context(batch_size: int) -> ThisContext:
         spy_tracker=spy_tracker,
         controller=controller,
     )
-
-
-@pytest.fixture
-def this_context() -> ThisContext:
-    return _make_context(batch_size=2)
 
 
 def test_should_store_all_frames(this_context: ThisContext) -> None:
@@ -150,15 +146,14 @@ def test_should_handle_empty_video(this_context: ThisContext) -> None:
     assert this_context.spy_tracker.called_with_detections == []
 
 
-def test_should_run_detection_per_batch() -> None:
+def test_should_run_detection_per_batch(this_context: ThisContext) -> None:
     # Given: 3 frames with batch_size=2 → one full batch + one partial
-    ctx = _make_context(batch_size=2)
-    ctx.video_reader.add(np.array([1], dtype=np.uint8))
-    ctx.video_reader.add(np.array([1], dtype=np.uint8))
-    ctx.video_reader.add(np.array([1], dtype=np.uint8))
+    this_context.video_reader.add(np.array([1], dtype=np.uint8))
+    this_context.video_reader.add(np.array([1], dtype=np.uint8))
+    this_context.video_reader.add(np.array([1], dtype=np.uint8))
 
     # When
-    ctx.controller.execute(SOURCE)
+    this_context.controller.execute(SOURCE)
 
     # Then: tracker called once per frame (3 total across 2 flush rounds)
-    assert len(ctx.spy_tracker.called_with_detections) == 3
+    assert len(this_context.spy_tracker.called_with_detections) == 3

--- a/tests/unit/test_track_objects.py
+++ b/tests/unit/test_track_objects.py
@@ -56,7 +56,6 @@ def this_context() -> ThisContext:
 
 def _detection(frame_id: FrameId, bbox: BoundingBox) -> Detection:
     return Detection(
-        video_id=VIDEO_ID,
         frame_id=frame_id,
         bbox=bbox,
     )
@@ -77,6 +76,7 @@ def test_should_start_a_new_track_on_unmatched_detection(this_context: ThisConte
     assert this_context.track_repository.list_open_tracks(VIDEO_ID) == [
         Track(
             id=TrackId(UUID("e435ff2c-33f4-577e-8a6d-f5a2b04a100b")),
+            video_id=VIDEO_ID,
             detections=[detection],
         ),
     ]
@@ -86,7 +86,9 @@ def test_should_extend_a_track_on_matched_detection(this_context: ThisContext):
     # Given
     first_detection = _detection(OTHER_FRAME_ID, BBOX)
     second_detection = _detection(FRAME_ID, BBOX)
-    this_context.track_repository.save(Track(id=IdFactory.new_track_id(first_detection), detections=[first_detection]))
+    this_context.track_repository.save(
+        Track(id=IdFactory.new_track_id(first_detection), video_id=VIDEO_ID, detections=[first_detection])
+    )
 
     # When
     this_context.use_case.execute(video_id=VIDEO_ID, detections=[second_detection])
@@ -95,6 +97,7 @@ def test_should_extend_a_track_on_matched_detection(this_context: ThisContext):
     assert this_context.track_repository.list_open_tracks(VIDEO_ID) == [
         Track(
             id=TrackId(UUID("4c3757bf-51e9-5e26-8dc4-ceb8e8913641")),
+            video_id=VIDEO_ID,
             detections=[first_detection, second_detection],
         ),
     ]
@@ -103,7 +106,9 @@ def test_should_extend_a_track_on_matched_detection(this_context: ThisContext):
 def test_should_close_a_track_after_grace_period_of_missed_frames(this_context: ThisContext):
     # Given: an open track whose bbox never matches the incoming frames
     unmatched_detection = _detection(OTHER_FRAME_ID, OTHER_BBOX)
-    unmatched_track = Track(id=IdFactory.new_track_id(unmatched_detection), detections=[unmatched_detection])
+    unmatched_track = Track(
+        id=IdFactory.new_track_id(unmatched_detection), video_id=VIDEO_ID, detections=[unmatched_detection]
+    )
     this_context.track_repository.save(unmatched_track)
 
     # When: the track is missed for the full grace period
@@ -117,7 +122,9 @@ def test_should_close_a_track_after_grace_period_of_missed_frames(this_context: 
 def test_should_keep_a_track_open_within_grace_period(this_context: ThisContext):
     # Given
     unmatched_detection = _detection(OTHER_FRAME_ID, OTHER_BBOX)
-    unmatched_track = Track(id=IdFactory.new_track_id(unmatched_detection), detections=[unmatched_detection])
+    unmatched_track = Track(
+        id=IdFactory.new_track_id(unmatched_detection), video_id=VIDEO_ID, detections=[unmatched_detection]
+    )
     this_context.track_repository.save(unmatched_track)
 
     # When: the track is missed but still within the grace period
@@ -131,7 +138,9 @@ def test_should_keep_a_track_open_within_grace_period(this_context: ThisContext)
 def test_should_reset_grace_period_when_track_is_matched_again(this_context: ThisContext):
     # Given: a track missed 3 times, then matched, then missed 4 more times
     first_detection = _detection(OTHER_FRAME_ID, BBOX)
-    this_context.track_repository.save(Track(id=IdFactory.new_track_id(first_detection), detections=[first_detection]))
+    this_context.track_repository.save(
+        Track(id=IdFactory.new_track_id(first_detection), video_id=VIDEO_ID, detections=[first_detection])
+    )
 
     for _ in range(3):
         this_context.use_case.execute(video_id=VIDEO_ID, detections=[])
@@ -150,11 +159,12 @@ def test_should_not_mix_tracks_across_videos(this_context: ThisContext):
     # Given: a track belonging to another video
     other_video_id = UUID("ffffffff-0000-0000-0000-000000000000")
     detection = Detection(
-        video_id=other_video_id,
         frame_id=OTHER_FRAME_ID,
         bbox=BBOX,
     )
-    this_context.track_repository.save(Track(id=IdFactory.new_track_id(detection), detections=[detection]))
+    this_context.track_repository.save(
+        Track(id=IdFactory.new_track_id(detection), video_id=other_video_id, detections=[detection])
+    )
 
     # When: tracking runs for a different video
     this_context.use_case.execute(video_id=VIDEO_ID, detections=[])

--- a/vigil/adapters/secondary/in_memory_track_repository.py
+++ b/vigil/adapters/secondary/in_memory_track_repository.py
@@ -20,4 +20,4 @@ class InMemoryTrackRepository(TrackRepository):
 
     def list_open_tracks(self, video_id: UUID) -> list[Track]:
         """List all open tracks for a given video."""
-        return [t for t in self._tracks.values() if not t.closed and t.detections[0].video_id == video_id]
+        return [t for t in self._tracks.values() if not t.closed and t.video_id == video_id]

--- a/vigil/business_logic/models/detection.py
+++ b/vigil/business_logic/models/detection.py
@@ -32,9 +32,6 @@ class BoundingBox:
 class Detection:
     """Represent an instance detection object."""
 
-    video_id: UUID
-    """Identifier of the video the detection belongs to."""
-
     frame_id: UUID
     """Identifier of the frame the detection was detected in."""
 

--- a/vigil/business_logic/models/track.py
+++ b/vigil/business_logic/models/track.py
@@ -18,6 +18,9 @@ class Track:
     id: TrackId
     """Track unique identifier."""
 
+    video_id: UUID
+    """Identifier of the video this track belongs to."""
+
     detections: list[Detection]
     """Detections associated with this track."""
 

--- a/vigil/business_logic/services/detection_service.py
+++ b/vigil/business_logic/services/detection_service.py
@@ -28,7 +28,6 @@ class DetectionService:
             for bbox in bboxes:
                 detections.append(
                     Detection(
-                        video_id=frame.video_id,
                         frame_id=frame.id,
                         bbox=bbox,
                     )

--- a/vigil/business_logic/use_cases/track_objects.py
+++ b/vigil/business_logic/use_cases/track_objects.py
@@ -20,7 +20,9 @@ class TrackObjectsUseCase:
         matches = self._tracker.update(tracks=open_tracks, detections=detections)
 
         for detection in self._orphan_detections(matches, detections):
-            self._track_repository.save(Track(id=IdFactory.new_track_id(detection), detections=[detection]))
+            self._track_repository.save(
+                Track(id=IdFactory.new_track_id(detection), video_id=video_id, detections=[detection])
+            )
 
         for track, detection in matches:
             self._track_repository.save(track.extend(detection))


### PR DESCRIPTION
Detection is now a pure value object (frame_id + bbox). Track owns the video context via a video_id field. InMemoryTrackRepository filters open tracks by Track.video_id directly, removing the implicit invariant that detection.video_id == track's video.

Closes #19 