### PR TITLE
:tada: Get analysis status use case

### DIFF
--- a/tests/unit/test_get_analysis_status.py
+++ b/tests/unit/test_get_analysis_status.py
@@ -1,0 +1,112 @@
+from collections.abc import Iterable
+from dataclasses import dataclass
+from uuid import UUID
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from vigil.adapters.secondary.in_memory_frame_repository import InMemoryFrameRepository
+from vigil.business_logic.gateways.video_reader import VideoReader
+from vigil.business_logic.models.frame import Frame, FrameId
+from vigil.business_logic.models.video_source import VideoSource
+from vigil.business_logic.services.id_factory import IdFactory
+from vigil.business_logic.use_cases.get_analysis_status import GetAnalysisStatusUseCase
+
+VIDEO_ID = IdFactory.new_video_id(VideoSource(uri="test-video"))
+
+
+class StubVideoReader(VideoReader):
+    """Controllable video reader for tests."""
+
+    def __init__(self) -> None:
+        self.total_frames: int = 0
+
+    def read(self, video_id: UUID) -> Iterable[npt.NDArray[np.uint8]]:
+        return []
+
+    def frame_count(self, video_id: UUID) -> int:
+        return self.total_frames
+
+
+@dataclass
+class ThisContext:
+    """Context for testing GetAnalysisStatusUseCase."""
+
+    frame_repository: InMemoryFrameRepository
+    video_reader: StubVideoReader
+    use_case: GetAnalysisStatusUseCase
+
+
+@pytest.fixture
+def this_context() -> ThisContext:
+    frame_repository = InMemoryFrameRepository()
+    video_reader = StubVideoReader()
+    use_case = GetAnalysisStatusUseCase(
+        frame_repository=frame_repository,
+        video_reader=video_reader,
+    )
+    return ThisContext(
+        frame_repository=frame_repository,
+        video_reader=video_reader,
+        use_case=use_case,
+    )
+
+
+def _create_frame(position: int) -> Frame:
+    return Frame(
+        id=FrameId(IdFactory.new_frame_id(video_id=VIDEO_ID, position=position)),
+        video_id=VIDEO_ID,
+        position=position,
+        data=np.array([position], dtype=np.uint8),
+    )
+
+
+def test_should_return_zero_analysed_frames_when_no_frames_stored(this_context: ThisContext) -> None:
+    # Given
+    this_context.video_reader.total_frames = 5
+
+    # When
+    status = this_context.use_case.execute(VIDEO_ID)
+
+    # Then
+    assert status.analysed_frames == 0
+
+
+def test_should_return_analysed_frames_count(this_context: ThisContext) -> None:
+    # Given
+    this_context.frame_repository.save(_create_frame(position=0))
+    this_context.frame_repository.save(_create_frame(position=1))
+    this_context.frame_repository.save(_create_frame(position=2))
+
+    # When
+    status = this_context.use_case.execute(VIDEO_ID)
+
+    # Then
+    assert status.analysed_frames == 3
+
+
+def test_should_return_total_frames_from_video_reader(this_context: ThisContext) -> None:
+    # Given
+    this_context.video_reader.total_frames = 42
+
+    # When
+    status = this_context.use_case.execute(VIDEO_ID)
+
+    # Then
+    assert status.total_frames == 42
+
+
+def test_should_reflect_partial_analysis_progress(this_context: ThisContext) -> None:
+    # Given: 3 frames stored out of 10 total
+    this_context.video_reader.total_frames = 10
+    this_context.frame_repository.save(_create_frame(position=0))
+    this_context.frame_repository.save(_create_frame(position=1))
+    this_context.frame_repository.save(_create_frame(position=2))
+
+    # When
+    status = this_context.use_case.execute(VIDEO_ID)
+
+    # Then
+    assert status.analysed_frames == 3
+    assert status.total_frames == 10

--- a/tests/unit/test_video_analysis_workflow.py
+++ b/tests/unit/test_video_analysis_workflow.py
@@ -34,6 +34,9 @@ class StubVideoReader(VideoReader):
     def read(self, video_id: UUID) -> Iterable[npt.NDArray[np.uint8]]:
         return self._frames
 
+    def frame_count(self, video_id: UUID) -> int:
+        return len(self._frames)
+
 
 class FakeDetectionModel(DetectionModel):
     """Returns one fixed prediction per non-empty frame, no prediction for all-

--- a/vigil/business_logic/gateways/video_reader.py
+++ b/vigil/business_logic/gateways/video_reader.py
@@ -12,3 +12,7 @@ class VideoReader(Protocol):
     def read(self, video_id: UUID) -> Iterable[npt.NDArray[np.uint8]]:
         """Read frames from a video."""
         ...
+
+    def frame_count(self, video_id: UUID) -> int:
+        """Return the total number of frames in a video."""
+        ...

--- a/vigil/business_logic/use_cases/get_analysis_status.py
+++ b/vigil/business_logic/use_cases/get_analysis_status.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from vigil.business_logic.gateways.frame_repository import FrameRepository
+from vigil.business_logic.gateways.video_reader import VideoReader
+
+
+@dataclass(frozen=True)
+class AnalysisStatus:
+    """Progress report for a video analysis job."""
+
+    analysed_frames: int
+    """Number of frames processed so far."""
+
+    total_frames: int
+    """Total number of frames in the video."""
+
+
+class GetAnalysisStatusUseCase:
+    """Return the progress of a video analysis job."""
+
+    def __init__(self, frame_repository: FrameRepository, video_reader: VideoReader) -> None:
+        self._frame_repository = frame_repository
+        self._video_reader = video_reader
+
+    def execute(self, video_id: UUID) -> AnalysisStatus:
+        """Return how many frames have been analysed out of the total."""
+        frames = self._frame_repository.get_by_video_id(video_id)
+        return AnalysisStatus(
+            analysed_frames=len(frames),
+            total_frames=self._video_reader.frame_count(video_id),
+        )


### PR DESCRIPTION
Adds a way to query the progress of an ongoing or completed video analysis job, given a video_id.

Closes #35 
closes #34 